### PR TITLE
Re-enable GDrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python scripts/download/download.py -h
 ```
 usage: download.py [-h] [--dataset {raw_30s,autotagging_moodtheme}]
                    [--type {audio,audio-low,melspecs,acousticbrainz}]
-                   [--from {mtg,mtg-fast}] [--unpack] [--remove]
+                   [--from {gdrive,mtg,mtg-fast}] [--unpack] [--remove]
                    outputdir
 
 Download the MTG-Jamendo dataset
@@ -100,9 +100,10 @@ options:
   --type {audio,audio-low,melspecs,acousticbrainz}
                         type of data to download (audio, audio in low quality,
                         mel-spectrograms, AcousticBrainz features) (default: audio)
-  --from {mtg,mtg-fast}
-                        download from MTG (server in Spain, slow),
-                        or fast MTG mirror (Finland) (default: mtg-fast)
+  --from {gdrive,mtg,mtg-fast}
+                        download from Google Drive (fast everywhere), MTG
+                        (server in Spain, slow), or fast MTG mirror (Finland)
+                        (default: mtg-fast)
   --unpack              unpack tar archives (default: False)
   --remove              remove tar archives while unpacking one by one (use to
                         save disk space) (default: False)

--- a/scripts/download/download.py
+++ b/scripts/download/download.py
@@ -1,13 +1,13 @@
 import argparse
-import sys
-import os.path
 import csv
 import hashlib
+import os.path
+import sys
 import tarfile
 from pathlib import Path
+
 import gdown
 import wget
-
 
 base_path = Path(__file__).parent
 ID_FILE_PATH = (base_path / "../../data/download/").resolve()
@@ -137,14 +137,10 @@ if __name__ == '__main__':
                         help='dataset to download')
     parser.add_argument('--type', default='audio', choices=['audio', 'audio-low', 'melspecs', 'acousticbrainz'],
                         help='type of data to download (audio, audio in low quality, mel-spectrograms, AcousticBrainz features)')
-    parser.add_argument('--from', default='mtg-fast', choices=['mtg', 'mtg-fast'],
-                        dest='download_from',
-                        help='download from MTG (server in Spain, slow), '
-                             'or fast MTG mirror (Finland)')
-    #parser.add_argument('--from', default='mtg-fast', choices=['gdrive', 'mtg', 'mtg-fast'],
-    #                    dest='download_from',
-    #                    help='download from Google Drive (fast everywhere), MTG (server in Spain, slow), '
-    #                         'or fast MTG mirror (Finland)')
+    parser.add_argument('--from', default='mtg-fast', choices=['gdrive', 'mtg', 'mtg-fast'],
+                       dest='download_from',
+                       help='download from Google Drive (fast everywhere), MTG (server in Spain, slow), '
+                            'or fast MTG mirror (Finland)')
     parser.add_argument('outputdir', help='directory to store the dataset')
     parser.add_argument('--unpack', action='store_true', help='unpack tar archives')
     parser.add_argument('--remove', action='store_true', help='remove tar archives while unpacking one by one (use to save disk space)')

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-gdown==4.2.1
+gdown==4.7.1
 matplotlib==3.5.1
 numpy==1.22.2
 pandas==1.4.0


### PR DESCRIPTION
Previously, Google Drive was disabled (5e80e0c0009decd279dd7cf67d1d2711a69c0c74). The problem was assumed to be because of too many downloads. However, by updating `gdown` to the latest version, we are able to download from GDrive again, so I think the problem is that the library is outdated (I think the fix happened here: https://github.com/wkentaro/gdown/commit/0848eadc4a98af0ed5a92bbcbab22cc433e249ad).