### PR TITLE
fix: Memory error during checksum validation

### DIFF
--- a/scripts/download/download.py
+++ b/scripts/download/download.py
@@ -19,13 +19,15 @@ download_from_names = {'gdrive': 'GDrive', 'mtg': 'MTG', 'mtg-fast': 'MTG Fast m
 
 CHUNK_SIZE = 512 * 1024  # 512KB
 
-
-def compute_sha256(filename):
+def compute_sha256(filename, chunk_size=8192):
+    sha256_hash = hashlib.sha256()
     with open(filename, 'rb') as f:
-        contents = f.read()
-        checksum = hashlib.sha256(contents).hexdigest()
-        return checksum
-
+        while True:
+            data = f.read(chunk_size)
+            if not data:
+                break
+            sha256_hash.update(data)
+    return sha256_hash.hexdigest()
 
 def download_from_mtg(url, output):
     output_path = Path(output)
@@ -116,7 +118,7 @@ def download(dataset, data_type, download_from, output_dir, unpack_tars, remove_
             download_from_mtg(url, output)
 
         # Validate the checksum.
-        if compute_sha256(output) != sha256_tars[filename]:
+        if compute_sha256(output, CHUNK_SIZE) != sha256_tars[filename]:
             print('%s does not match the checksum, removing the file' % output, file=sys.stderr)
             removed.append(filename)
             os.remove(output)


### PR DESCRIPTION
### Issue:
This pull request addresses a MemoryError issue encountered when computing the SHA256 checksum for validation of each downloaded tar

### Changes:

Modified the compute_sha256 function to read files in chunks rather than loading them entirely into memory.

Verified the fix, the script is able to run without a crash

Included screenshots demonstrating the issue before the fix and the successful execution after the fix.
Added system memory usage information (free -h) to provide context for a system where the issue should be replicable

### Screenshots:

Screenshot 1: Error encountered when processing a download
<img width="1440" alt="Screenshot 2024-03-23 at 3 25 58 PM" src="https://github.com/MTG/mtg-jamendo-dataset/assets/21192688/4986a1bf-bbe6-4fb1-aae0-c427a4d9abbd">

Screenshot 2: Successful execution after implementing chunked reading
<img width="1440" alt="Screenshot 2024-03-23 at 3 39 29 PM" src="https://github.com/MTG/mtg-jamendo-dataset/assets/21192688/ef1434fe-027d-4883-9e55-47c401937e94">


System Memory Usage
<img width="645" alt="Screenshot 2024-03-23 at 4 12 17 PM" src="https://github.com/MTG/mtg-jamendo-dataset/assets/21192688/19c37ae8-b957-470c-b397-d663ccef8d0e">
